### PR TITLE
removing description attribute from package-noclean

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -71,7 +71,7 @@
     </scalac>
   </target>
 
-  <target name="package-noclean" depends="compile" description="Package server into WAR file">
+  <target name="package-noclean" depends="compile">
     <!-- Delete and recreate to clean out old libraries, since <copy> doesn't do that -->
     <delete dir="${build-lib}"/>
     <mkdir dir="${build-lib}"/>
@@ -95,7 +95,7 @@
   </target>
 
   <target name="package" depends="clean,package-noclean"
-          description="Package server into WAR file with a fresh compile"/>
+          description="Package server into WAR file."/>
 
   <target name="run" depends="compile" description="Run the server.">
     <java classname="Hello">


### PR DESCRIPTION
When you do "ant -p" it shows you a list of all the "major" ant tasks, i.e. the ones that have descriptions.
I think this is the best solution for now: the noclean target is still there if you want it, but it makes it more implausible that someone would do a release with a war that contains stale class files.

We don't have a write-compile-deploy-test cycle yet, and the Scala compiler is already slow.  Sloooow.  I think the best way to speed up that cycle is to write things in layers, keep the layers separate, and run tests on one layer at a time so you don't have to spin up the web server to test every new piece of functionality.  (I have yet to work on a project where that's the case, but there's always a first time..)
