### PR TITLE
refs #11: adding primitive methods to add and remove pieces to the board, and Board.toString

### DIFF
--- a/src/main/scala/org/playarimaa/board/Board.scala
+++ b/src/main/scala/org/playarimaa/board/Board.scala
@@ -67,6 +67,42 @@ class Board(
       }
     }
 
+  /**
+   * Primitive method called to add a new piece to the board.
+   * If the location is currently empty, returns a new board with the piece added.
+   * Otherwise returns an error.
+   */
+  def add(piece: Piece, loc: Location): Try[Board] = {
+    this(loc) match {
+      case OffBoard => Failure(new IllegalArgumentException("Bad location: " + loc))
+      case HasPiece(p) => Failure(new IllegalStateException("Square " + loc + " already occupied with " + p))
+      case Empty => {
+        val newPieces = pieces  + (loc -> piece)
+        Success(new Board(newPieces, player, stepsLeft))
+      }
+    }
+  }
+
+  /**
+   * Primitive method called to remove a piece from the board.
+   * If there is currently the correct piece at the correct location, returns a new board with the piece removed.
+   * Otherwise returns an error.
+   */
+  def remove(piece: Piece, loc: Location): Try[Board] = {
+    this(loc) match {
+      case OffBoard => Failure(new IllegalArgumentException("Bad location: " + loc))
+      case Empty => Failure(new IllegalStateException("Square " + loc + " is empty."))
+      case HasPiece(p) => {
+        if (p equals piece) {
+          val newPieces = pieces  - loc
+          Success(new Board(newPieces, player, stepsLeft))
+        } else {
+          Failure(new IllegalArgumentException("Location " + loc + " has " + p + ", trying to remove " + piece))
+        }
+      }
+    }
+  }
+
   /** Make the specified placements, returning the new board.
     * Returns Error if placements are not on unique empty locations
     * OR if the resulting position has an unguarded piece on a trap
@@ -99,6 +135,25 @@ class Board(
   def endTurn: Board =
     new Board(pieces, player.flip, Board.STEPS_PER_TURN)
 
+  def toStringAei : String = {
+    val returnVal : StringBuilder = new StringBuilder
+    returnVal.append("[")
+    Location.valuesAei foreach {
+      ((loc : Location) => {
+        this(loc) match {
+          case OffBoard => throw new AssertionError("Bad location: " + loc)
+          case HasPiece(p) => returnVal.append(p.toChar)
+          case Empty => returnVal.append(' ')
+        }
+      })
+    }
+    returnVal.append("]")
+    returnVal.toString
+  }
+  
+  override def toString = {
+    toStringAei
+  }
 }
 
 object Board {

--- a/src/main/scala/org/playarimaa/board/Location.scala
+++ b/src/main/scala/org/playarimaa/board/Location.scala
@@ -36,6 +36,13 @@ object Location {
     Success(Location(x,y))
   }
 
+  /** Returns values in AEI order (a8-h8, a7-h7...a1-h1) */
+  val valuesAei: List[Location] = (
+    for(y <- 7 to 0 by -1; x <- 0 to 7)
+    yield Location(x,y)
+    )(collection.breakOut)
+
+  /** Returns values: (a1-h1, a2-h2, ... a8-h8) */
   val values: List[Location] = (
     for(y <- 0 to 7; x <- 0 to 7)
     yield Location(x,y)

--- a/src/test/scala/BoardTests.scala
+++ b/src/test/scala/BoardTests.scala
@@ -21,25 +21,13 @@ class BoardTests extends FlatSpec with Matchers {
   "Board" should "not be larger than size 9 due to notation" in {
     assert(Board.SIZE <= 9)
   }
-}
 
-/*
-import org.scalatest.junit.JUnitSuite
-import org.junit.Assert.assertTrue
-import org.junit.Assert.assertFalse
-import org.junit.Test
-
-import org.playarimaa.util._
-import org.playarimaa.board._
-
-class PieceTest extends JUnitSuite {
-
-  @Test
-  def testPiece() {
-    Piece.values.foreach( piece =>
-      assertTrue(Piece.ofChar(piece.toChar) == Ok(piece))
-    )
+  it should "print toStringAei correctly" in {
+    new Board().toStringAei should be ("[                                                                ]")
+    new Board().add(new Piece(GOLD, RAB), Location.ofString("a8").get).get
+        .toStringAei should be ("[R                                                               ]")
+    new Board().add(new Piece(SILV, RAB), Location.ofString("a8").get).get
+        .add(new Piece(GOLD, HOR), Location.ofString("b1").get).get
+        .toStringAei should be ("[r                                                        H      ]")
   }
 }
-
- */


### PR DESCRIPTION
I implemented a method Board.toStringAei so I can easily convert a Board into a standardized string, so I can easily test that the board manipulations were done properly.

My test works but the syntax is super clunky.
- Location.apply -> Location.ofString?
- Case classes for Piece?  There are only 12 possibilities.

I'd like to write more tests after I streamline the syntax.
