### PR TITLE
Patch compilation issue involving resolution of ambiguous IOTypes due to it being present at global scope

### DIFF
--- a/src/main/scala/org/playarimaa/server/ArimaaServlet.scala
+++ b/src/main/scala/org/playarimaa/server/ArimaaServlet.scala
@@ -9,9 +9,13 @@ import org.json4s.jackson.Serialization
 import org.playarimaa.server.CommonTypes._
 import org.playarimaa.server.Utils._
 
-object IOTypes {
-  case class SimpleError(error: String)
+object ArimaaServlet {
+  object IOTypes {
+    case class SimpleError(error: String)
+  }
 }
+
+import org.playarimaa.server.AccountServlet._
 
 class ArimaaServlet(val siteLogin: SiteLogin)
     extends WebAppStack with JacksonJsonSupport with ScalateSupport {


### PR DESCRIPTION
Not sure if there's a more Scala-idomatic way to structure this. This removes IOTypes from global package scope, so that it doesn't ambiguousify with IOTypes objects in other files, fixing a compile error mattj ran into.
